### PR TITLE
fix(testnet): Add `asset` module codec

### DIFF
--- a/utils/codec.go
+++ b/utils/codec.go
@@ -33,6 +33,7 @@ import (
 	multistakingtypes "github.com/realio-tech/multi-staking-module/x/multi-staking/types"
 	ethcryptocodec "github.com/realiotech/realio-network/crypto/codec"
 	bridgemoduletypes "github.com/realiotech/realio-network/x/bridge/types"
+	assetmoduletypes "github.com/realiotech/realio-network/x/asset/types"
 
 	// evmtypes "github.com/evmos/os/x/evm/types"
 	cosmosevmcryptocodec "github.com/cosmos/evm/crypto/codec"
@@ -54,6 +55,7 @@ func GetCodec() codec.Codec {
 		ibcclientv10types.RegisterInterfaces(interfaceRegistry)
 		multistakingtypes.RegisterInterfaces(interfaceRegistry)
 		bridgemoduletypes.RegisterInterfaces(interfaceRegistry)
+		assetmoduletypes.RegisterInterfaces(interfaceRegistry)
 		std.RegisterInterfaces(interfaceRegistry)
 		cdc = codec.NewProtoCodec(interfaceRegistry)
 	})


### PR DESCRIPTION
- missing asset module codec for testnet