### PR TITLE
fix: Duplicate events in `handle_block`

### DIFF
--- a/database/multistaking.go
+++ b/database/multistaking.go
@@ -11,11 +11,17 @@ import (
 )
 
 func (db *Db) SaveMultiStakingLocks(height int64, multiStakingLocks []*multistakingtypes.MultiStakingLock) error {
+	query := "DELETE FROM ms_locks"
+	_, err := db.SQL.Exec(query)
+	if err != nil {
+		return fmt.Errorf("error while deleting ms_unlocks: %s", err)
+	}
+
 	if len(multiStakingLocks) == 0 {
 		return nil
 	}
 
-	query := `INSERT INTO ms_locks (staker_addr, val_addr, denom, amount, bond_weight, height) VALUES`
+	query = `INSERT INTO ms_locks (staker_addr, val_addr, denom, amount, bond_weight, height) VALUES`
 
 	var param []interface{}
 
@@ -36,7 +42,7 @@ ON CONFLICT (staker_addr, val_addr) DO UPDATE
 		height = excluded.height
 WHERE ms_locks.height <= excluded.height`
 
-	_, err := db.SQL.Exec(query, param...)
+	_, err = db.SQL.Exec(query, param...)
 	if err != nil {
 		return fmt.Errorf("error while saving msLock: %s", err)
 	}
@@ -45,11 +51,18 @@ WHERE ms_locks.height <= excluded.height`
 }
 
 func (db *Db) SaveMultiStakingUnlocks(height int64, multiStakingUnlocks []*multistakingtypes.MultiStakingUnlock) error {
+
+	query := "DELETE FROM ms_unlocks"
+	_, err := db.SQL.Exec(query)
+	if err != nil {
+		return fmt.Errorf("error while deleting ms_unlocks: %s", err)
+	}
+
 	if len(multiStakingUnlocks) == 0 {
 		return nil
 	}
 
-	query := `INSERT INTO ms_unlocks (staker_addr, val_addr, creation_height, denom, amount, bond_weight, height) VALUES`
+	query = `INSERT INTO ms_unlocks (staker_addr, val_addr, creation_height, denom, amount, bond_weight, height) VALUES`
 
 	var param []interface{}
 	count := 0
@@ -74,7 +87,7 @@ ON CONFLICT (staker_addr, val_addr, creation_height) DO UPDATE
 		height = excluded.height
 WHERE ms_unlocks.height <= excluded.height`
 
-	_, err := db.SQL.Exec(query, param...)
+	_, err = db.SQL.Exec(query, param...)
 	if err != nil {
 		return fmt.Errorf("error while saving msUnlock: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/proullon/ramsql v0.1.3
 	github.com/realio-tech/multi-staking-module v0.0.0-00010101000000-000000000000
-	github.com/realiotech/realio-network v1.4.0-rc1
+	github.com/realiotech/realio-network v1.4.0
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -408,7 +408,7 @@ replace (
 	// use cosmos flavored protobufs
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/realio-tech/multi-staking-module => github.com/realiotech/multi-staking v1.1.0-rc1
+	github.com/realio-tech/multi-staking-module => github.com/realiotech/multi-staking v1.1.0
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -1242,10 +1242,10 @@ github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Ung
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/realiotech/multi-staking v1.1.0-rc1 h1:fv/NiVyTbr+umXq0Mi+8UvqdY33xQCiygjxd5KpvIes=
-github.com/realiotech/multi-staking v1.1.0-rc1/go.mod h1:jNjSslDy7t9OozYsFShqRmjPrKCQV6Do4VhXRKYmh2A=
-github.com/realiotech/realio-network v1.4.0-rc1 h1:2BClxVHjdB+BBIaAAJmbLx42uBiY0wXtjg+JQ++tPKc=
-github.com/realiotech/realio-network v1.4.0-rc1/go.mod h1:2a+QlWRs5fKbjCJrmhgu7n7kETKVV4W6wxMuQFVrUa4=
+github.com/realiotech/multi-staking v1.1.0 h1:sr98X2oSUoV4KRP31pAIp+8F0xLSxv1i4/XyXvA75iw=
+github.com/realiotech/multi-staking v1.1.0/go.mod h1:jNjSslDy7t9OozYsFShqRmjPrKCQV6Do4VhXRKYmh2A=
+github.com/realiotech/realio-network v1.4.0 h1:9l91Cn6z7lYp4coi9n9DdeYMQizcG1bHsq715z0AVkI=
+github.com/realiotech/realio-network v1.4.0/go.mod h1:f3sKM9uzW7ogviGiR5QFe1llcB5BVQdxUx+XIWqj33M=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1 h1:OHEc+q5iIAXpqiqFKeLpu5NwTIkVXUs48vFMwzqpqY4=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1/go.mod h1:2DjTFR1HhMQhiWC5sZ4OhQ3+NtdbZ6oBDKQwq5Ou+FI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/modules/multistaking/handle_additional_operations.go
+++ b/modules/multistaking/handle_additional_operations.go
@@ -53,6 +53,7 @@ func (m *Module) UpdateMultiStakingLocks(height int64) error {
 		return err
 	}
 
+	// Drop old table and reset ms_lock from state
 	return m.db.SaveMultiStakingLocks(height, multiStakingLocks)
 }
 
@@ -64,12 +65,12 @@ func (m *Module) UpdateMultiStakingUnlocks(height int64) error {
 	if err != nil {
 		return err
 	}
-
 	err = m.db.SaveUnbondingToken(height, multiStakingUnlocks)
 	if err != nil {
 		return err
 	}
 
+	// Drop old table and reset ms_unlock from state
 	return m.db.SaveMultiStakingUnlocks(height, multiStakingUnlocks)
 }
 

--- a/modules/multistaking/handle_block.go
+++ b/modules/multistaking/handle_block.go
@@ -19,12 +19,8 @@ import (
 func (m *Module) HandleBlock(
 	block *tmctypes.ResultBlock, res *tmctypes.ResultBlockResults, _ []*juno.Transaction, _ *tmctypes.ResultValidators,
 ) error {
-	events := res.FinalizeBlockEvents
-	for _, tx := range res.TxsResults {
-		events = append(events, tx.Events...)
-	}
 
-	err := m.updateTxsByEvent(block.Block.Height, events)
+	err := m.updateTxsByEvent(block.Block.Height, res.FinalizeBlockEvents)
 	if err != nil {
 		fmt.Printf("Error when updateTxsByEvent, error: %s", err)
 	}
@@ -36,19 +32,8 @@ func (m *Module) updateTxsByEvent(height int64, events []abci.Event) error {
 		Msg("updating txs by event")
 
 	var msEvents []dbtypes.MSEvent
-	var delegator abci.EventAttribute
 	for _, event := range events {
 		switch event.Type {
-		// Use for Redelegate case, it missing delegator address
-		// So we get it from withdraw_rewards event
-		case "withdraw_rewards":
-			delegator, _ = juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
-		case stakingtypes.EventTypeCreateValidator:
-			valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
-			valAcc, _ := sdk.ValAddressFromBech32(valAddr.Value)
-			delAddr := sdk.AccAddress(valAcc)
-			m.UpdateLockAndUnlockInfo(height, delAddr.String(), valAddr.Value)
-
 		case stakingtypes.EventTypeDelegate:
 			valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
 			delAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
@@ -58,7 +43,6 @@ func (m *Module) updateTxsByEvent(height int64, events []abci.Event) error {
 			if err == nil {
 				msEvents = append(msEvents, msEvent)
 			}
-			m.UpdateLockAndUnlockInfo(height, delAddr.Value, valAddr.Value)
 
 		case stakingtypes.EventTypeUnbond:
 			valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
@@ -69,7 +53,6 @@ func (m *Module) updateTxsByEvent(height int64, events []abci.Event) error {
 			if err == nil {
 				msEvents = append(msEvents, msEvent)
 			}
-			m.UpdateLockAndUnlockInfo(height, delAddr.Value, valAddr.Value)
 
 		case stakingtypes.EventTypeCancelUnbondingDelegation:
 			valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
@@ -80,20 +63,12 @@ func (m *Module) updateTxsByEvent(height int64, events []abci.Event) error {
 			if err == nil {
 				msEvents = append(msEvents, msEvent)
 			}
-			m.UpdateLockAndUnlockInfo(height, delAddr.Value, valAddr.Value)
-
 		case stakingtypes.EventTypeCompleteRedelegation:
 			valAddr1, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeySrcValidator)
 			valAddr2, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDstValidator)
 			delAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
 			m.UpdateLockAndUnlockInfo(height, delAddr.Value, valAddr1.Value)
 			m.UpdateLockAndUnlockInfo(height, delAddr.Value, valAddr2.Value)
-
-		case stakingtypes.EventTypeRedelegate:
-			valAddr1, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeySrcValidator)
-			valAddr2, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDstValidator)
-			m.UpdateLockAndUnlockInfo(height, delegator.Value, valAddr1.Value)
-			m.UpdateLockAndUnlockInfo(height, delegator.Value, valAddr2.Value)
 
 		case stakingtypes.EventTypeCompleteUnbonding:
 			valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)

--- a/modules/multistaking/handle_msg.go
+++ b/modules/multistaking/handle_msg.go
@@ -4,22 +4,30 @@ import (
 	"fmt"
 
 	cosmossdk_io_math "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/rs/zerolog/log"
 
 	juno "github.com/forbole/juno/v6/types"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	dbtypes "github.com/forbole/callisto/v4/database/types"
 	"github.com/forbole/callisto/v4/utils"
 	multistakingtypes "github.com/realio-tech/multi-staking-module/x/multi-staking/types"
 )
 
 var msgFilter = map[string]bool{
-	"/cosmos.staking.v1beta1.MsgCreateValidator": true,
-	"/cosmos.staking.v1beta1.MsgEditValidator":   true,
-	"/cosmos.staking.v1beta1.MsgDelegate":        true,
-	"/cosmos.staking.v1beta1.MsgUndelegate":      true,
-	"/cosmos.staking.v1beta1.MsgBeginRedelegate": true,
+	"/cosmos.staking.v1beta1.MsgCreateValidator":    true,
+	"/cosmos.staking.v1beta1.MsgEditValidator":      true,
+	"/cosmos.staking.v1beta1.MsgDelegate":           true,
+	"/cosmos.staking.v1beta1.MsgUndelegate":         true,
+	"/cosmos.staking.v1beta1.MsgBeginRedelegate":    true,
+	"/cosmos.evm.vm.v1.MsgEthereumTx":               true,
+	"/multistaking.v1.MsgDelegateEVM":               true,
+	"/multistaking.v1.MsgUndelegateEVM":             true,
+	"/multistaking.v1.CancelUnbondingEVMDelegation": true,
+	"/multistaking.v1.MsgCreateEVMValidator":        true,
+	"/multistaking.v1.MsgBeginRedelegateEVM":        true,
 }
 
 // HandleMsgExec implements modules.AuthzMessageModule
@@ -39,9 +47,15 @@ func (m *Module) HandleMsg(_ int, msg juno.Message, tx *juno.Transaction) error 
 	case "/cosmos.staking.v1beta1.MsgCreateValidator":
 		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &stakingtypes.MsgCreateValidator{})
 		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
+	case "/multistaking.v1.MsgCreateEVMValidator":
+		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &multistakingtypes.MsgCreateEVMValidator{})
+		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
 
 	case "/cosmos.staking.v1beta1.MsgDelegate":
 		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &stakingtypes.MsgDelegate{})
+		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
+	case "/multistaking.v1.MsgDelegateEVM":
+		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &multistakingtypes.MsgDelegateEVM{})
 		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
 
 	case "/cosmos.staking.v1beta1.MsgBeginRedelegate":
@@ -52,14 +66,81 @@ func (m *Module) HandleMsg(_ int, msg juno.Message, tx *juno.Transaction) error 
 		}
 
 		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorSrcAddress)
+	case "/multistaking.v1.MsgBeginRedelegateEVM":
+		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &multistakingtypes.MsgBeginRedelegateEVM{})
+		err := m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorDstAddress)
+		if err != nil {
+			return err
+		}
+
+		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorSrcAddress)
 
 	case "/cosmos.staking.v1beta1.MsgUndelegate":
 		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &stakingtypes.MsgUndelegate{})
 		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
+	case "/multistaking.v1.MsgUndelegateEVM":
+		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &multistakingtypes.MsgUndelegateEVM{})
+		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
 
 	case "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation":
 		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &stakingtypes.MsgCancelUnbondingDelegation{})
-		return m.UpdateLockAndUnlockInfo(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
+		return m.CompleteUnbonding(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
+	case "/multistaking.v1.CancelUnbondingEVMDelegation":
+		cosmosMsg := utils.UnpackMessage(m.cdc, msg.GetBytes(), &multistakingtypes.MsgCancelUnbondingEVMDelegation{})
+		return m.CompleteUnbonding(int64(tx.Height), cosmosMsg.DelegatorAddress, cosmosMsg.ValidatorAddress)
+
+	case "/cosmos.evm.vm.v1.MsgEthereumTx":
+		// For evm tx, handle by event
+		events := tx.Events
+		var delegator abci.EventAttribute
+		EventLoop:for _, event := range events {
+			switch event.Type {
+			// Use for Redelegate case, it missing delegator address
+			// So we get it from withdraw_rewards event
+			case "withdraw_rewards":
+				delegator, _ = juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
+			case stakingtypes.EventTypeCreateValidator:
+				valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
+				valAcc, _ := sdk.ValAddressFromBech32(valAddr.Value)
+				delAddr := sdk.AccAddress(valAcc)
+				m.UpdateLockAndUnlockInfo(int64(tx.Height), delAddr.String(), valAddr.Value)
+				// break loop to avoid duplicate events
+				break EventLoop
+
+			case stakingtypes.EventTypeDelegate:
+				valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
+				delAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
+
+				m.UpdateLockAndUnlockInfo(int64(tx.Height), delAddr.Value, valAddr.Value)
+				// break loop to avoid duplicate events
+				break EventLoop
+
+			case stakingtypes.EventTypeUnbond:
+				valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
+				delAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
+				m.UpdateLockAndUnlockInfo(int64(tx.Height), delAddr.Value, valAddr.Value)
+				// break loop to avoid duplicate events
+				break EventLoop
+
+			case stakingtypes.EventTypeCancelUnbondingDelegation:
+				valAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyValidator)
+				delAddr, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDelegator)
+				
+				m.CompleteUnbonding(int64(tx.Height), delAddr.Value, valAddr.Value)
+				// break loop to avoid duplicate events
+				break EventLoop
+
+			case stakingtypes.EventTypeRedelegate:
+				valAddr1, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeySrcValidator)
+				valAddr2, _ := juno.FindAttributeByKey(event, stakingtypes.AttributeKeyDstValidator)
+				m.UpdateLockAndUnlockInfo(int64(tx.Height), delegator.Value, valAddr1.Value)
+				m.UpdateLockAndUnlockInfo(int64(tx.Height), delegator.Value, valAddr2.Value)
+				// break loop to avoid duplicate events
+				break EventLoop
+
+			}
+		}
+
 	}
 
 	return nil


### PR DESCRIPTION
- staking tx event like `delegate`, `unbond`,... appear twice for each transaction so current bonded and unbonding token logic not correctly
- handle `/multistaking` msg types specificly
- handle `/cosmos.evm.vm.v1.MsgEthereumTx` msg type by events (avoided duplicate)